### PR TITLE
Update requirements - add plum-py

### DIFF
--- a/custom_components/hoymiles_dtu/manifest.json
+++ b/custom_components/hoymiles_dtu/manifest.json
@@ -2,7 +2,7 @@
   "domain": "hoymiles_dtu",
   "name": "Hoymiles Plant DTU-Pro",
   "documentation": "https://github.com/ArekKubacki/Hoymiles-Plant-DTU-Pro",
-  "requirements": ["hoymiles_modbus>=0.6.0"],
+  "requirements": ["hoymiles_modbus>=0.6.0","plum-py>=0.8.6"],
   "dependencies": [],
   "codeowners": [],
   "version": "0.5.0",


### PR DESCRIPTION
If the "plum-py" module is not listed in the "requirements" section the component fails to start in hass (running in docker container) with the following error: ModuleNotFoundError: No module named 'plum'